### PR TITLE
Add caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 > [MoonZoon](http://moonzoon.rs/) is a Rust Fullstack Framework.
 
-The current purpose of this buildpack is to make [MoonZoon demo](https://github.com/MoonZoon/demo) work. It means it does only the essential things and nothing more (e.g. caching).
+The current purpose of this buildpack is to make [MoonZoon demo](https://github.com/MoonZoon/demo) work. It means that there is basic functionallity.
 
 It's tested with [Heroku](https://www.heroku.com/), however there is a chance it works also with a Heroku-like PaaSs like [Dokku](https://dokku.com/).

--- a/bin/compile
+++ b/bin/compile
@@ -1,19 +1,38 @@
 #!/bin/bash
 
 BUILD_DIR=${1:-}
+CACHE_DIR=${2:-}
 
-echo "-----> Installing Rust"
-curl https://sh.rustup.rs -sSf > rustup.sh
-chmod u+x rustup.sh
-./rustup.sh -y
-rm rustup.sh
-source $HOME/.cargo/env
-rustc -V
+mkdir -p "$CACHE_DIR"
+cd "$CACHE_DIR"
 
-cd $BUILD_DIR
+export RUSTUP_HOME="$CACHE_DIR/rustup"
+export CARGO_HOME="$CACHE_DIR/cargo"
+
+if [ -d "$CARGO_HOME" ]; then
+    echo "-----> Check for up-to-date Rust installation"
+    source "$CARGO_HOME/env"
+    rustup self update
+    rustup update stable
+else
+    echo "-----> Installing Rust"
+    curl https://sh.rustup.rs -sSf > rustup.sh
+    chmod u+x rustup.sh
+    ./rustup.sh -y --default-toolchain stable
+    rm rustup.sh
+    source "$CARGO_HOME/env"
+fi
+
+# Store all generated artifacts in cache dir
+export CARGO_TARGET_DIR="$CACHE_DIR/target"
 
 echo "-----> Installing MZoon"
-cargo install mzoon --git https://github.com/MoonZoon/MoonZoon --rev $(<mzoon_commit) --root cargo_install_root --locked
+cargo install mzoon --git https://github.com/MoonZoon/MoonZoon --rev $(<"$BUILD_DIR/mzoon_commit") --root "$CACHE_DIR/mzoon_install_root" --locked
+MZOON="$CACHE_DIR/mzoon_install_root/bin/mzoon"
+
+cd "$BUILD_DIR"
 
 echo "-----> Building app"
-cargo_install_root/bin/mzoon build -r
+"$MZOON" build -r
+mkdir -p target/release
+find "$CARGO_TARGET_DIR/release" -maxdepth 1 -type f -executable -exec cp -a -t target/release {} \;


### PR DESCRIPTION
Add caching of the rustup/rust installation, mzoon installation and artifacts of the app.

If the same source is deployed twice, the dependencies of the backend and frontend crates are cached. But the binaries itself are always rebuilt, maybe because the name of the BUILD_DIR changes?