### PR TITLE
Add Mzoon Build path environment variable

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -2,6 +2,29 @@
 
 BUILD_DIR=${1:-}
 CACHE_DIR=${2:-}
+ENV_DIR=${3:-}
+
+
+# Path of mzoon root directory
+MZOON_BUILD_PATH="."
+
+
+# From https://devcenter.heroku.com/articles/buildpack-api
+export_env_dir() {
+  env_dir=$1
+  acceptlist_regex=${2:-''}
+  denylist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
+  if [ -d "$env_dir" ]; then
+    for e in $(ls $env_dir); do
+      echo "$e" | grep -E "$acceptlist_regex" | grep -qvE "$denylist_regex" &&
+      export "$e=$(cat $env_dir/$e)"
+      :
+    done
+  fi
+}
+
+export_env_dir "$ENV_DIR"
+
 
 mkdir -p "$CACHE_DIR"
 cd "$CACHE_DIR"
@@ -27,10 +50,11 @@ fi
 export CARGO_TARGET_DIR="$CACHE_DIR/target"
 
 echo "-----> Installing MZoon"
-cargo install mzoon --git https://github.com/MoonZoon/MoonZoon --rev $(<"$BUILD_DIR/mzoon_commit") --root "$CACHE_DIR/mzoon_install_root" --locked
+echo "Entering MZOON_BUILD_PATH: $MZOON_BUILD_PATH"
+cd "$BUILD_DIR/$MZOON_BUILD_PATH"
+cargo install mzoon --git https://github.com/MoonZoon/MoonZoon --rev $(<mzoon_commit) --root "$CACHE_DIR/mzoon_install_root" --locked
 MZOON="$CACHE_DIR/mzoon_install_root/bin/mzoon"
 
-cd "$BUILD_DIR"
 
 echo "-----> Building app"
 "$MZOON" build -r


### PR DESCRIPTION
This PR makes herokus environment variables available in the compile script (`heroku config:set MZOON_BUILD_PATH=app`) and builds the app specified by the path.

The detect script is still looking for a `MoonZoon.toml` att the root, since its not possible to use the environment variable in the detect script. Do you have an idea how to solve this? To test I created a dummy `MoonZoon.toml`.

The Procfile has to remain in the root with the content: `web: "$MZOON_BUILD_PATH/target/release/backend"`